### PR TITLE
added classes aren't in the classmap generated by composer - changing th...

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,11 @@
         "zendframework/zendframework": "dev-master"
     },
     "autoload": {
+        "psr-0": {
+            "SlmLocale": "src/"
+        },
         "classmap": [
-            "./"
+            "./Module.php"
         ]
     }
 }


### PR DESCRIPTION
...e autoload load key _might_ change that.

ok, i just confirmed this to work by updating my project composer to this branch and unittest all branches. no class not found errors for branches that had them before...
