### PR TITLE
Auto-specify locale options in View/Helper/LocaleUrl

### DIFF
--- a/src/SlmLocale/View/Helper/LocaleUrl.php
+++ b/src/SlmLocale/View/Helper/LocaleUrl.php
@@ -106,6 +106,11 @@ class LocaleUrl extends AbstractHelper
          * route match is present, we've a 404 and grab the path from the request object.
          */
         if ($this->getRouteMatch()) {
+
+            if (!isset($options['locale'])) {
+                $options['locale'] = $locale;
+            }
+
             $url = $this->getView()->url($name, $params, $options, $reuseMatchedParams);
         } else {
             $url = $this->getRequest()->getUri()->getPath();


### PR DESCRIPTION
I have translated part in url :  

/fr/contacter-nous
/en/contact-us

Config :  

``` php
'contact' => array(
    'type' => 'Segment',
    'options' => array(
        'route' => '/{contact}',
        'defaults' => array(
            'controller' => 'App\Controller\Contact',
            'action' => 'index',
        ),
    ),
),
```

If I want to generate the url, I have to use do :  

``` php
// I am currently in /fr/contacter-nous

$this->localeUrl('en'); // return /en/contacter-nous

$this->localeUrl('en', null, array(), array('locale' => 'en')); // return /en/contact-us

```

Why don't auto set 'locale' to 'en' ?
Like this, event LocaleMenu is usable.
