### PR TITLE
Allow ZF2.3 to be installed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,14 +19,14 @@
     "require": {
         "php": ">=5.3.3.",
         "ext-intl": "*",
-        "zendframework/zend-eventmanager": "~2.1.0",
-        "zendframework/zend-http": "~2.1.0",
-        "zendframework/zend-servicemanager": "~2.1.0",
-        "zendframework/zend-stdlib": "~2.1.0"
+        "zendframework/zend-eventmanager": "~2.1",
+        "zendframework/zend-http": "~2.1",
+        "zendframework/zend-servicemanager": "~2.1",
+        "zendframework/zend-stdlib": "~2.1"
     },
     "require-dev": {
-        "zendframework/zend-console": "~2.1.0",
-        "zendframework/zend-mvc": "~2.1.0"
+        "zendframework/zend-console": "~2.1",
+        "zendframework/zend-mvc": "~2.1"
     },
     "suggest": {
         "zendframework/zend-mvc": "For using the router in the UriPath strategy"


### PR DESCRIPTION
The ~x.y notation allows any version of x where x.n >= x.y. This means that previously only 2.1.x and 2.2.x were allowed, now all new versions (like 2.3.x and so on) can be used as well.

Fixes #52 
