### PR TITLE
Locale mapping feature

### DIFF
--- a/config/slmlocale.global.php.dist
+++ b/config/slmlocale.global.php.dist
@@ -23,6 +23,14 @@ $settings = array(
      * Accepted is something else
      */
     //'supported' => array('en-US', 'en-GB'),
+    
+    /**
+     * Locale mappings
+     *
+     * An array of mappings to apply where the indexes correspond to the 
+     * detected locale, and the values to the locale to map it to.
+     */
+    //'mappings' => array('en' => 'en-US', 'fr' => 'fr_FR'),
 
     /**
      * Strategies

--- a/docs/1.Introduction.md
+++ b/docs/1.Introduction.md
@@ -10,7 +10,7 @@ The strategies can also be called when a locale is found. This is useful for exa
 
 Detector options
 ---
-The detector has a few options to tune the detection mechanism. First, there is a default locale. When every strategy sought for a locale, but did not find any, the default locale will be set. There is also a list of supported locales. Your application will probably not support every available locale, so you could define a set and SlmLocale tries to identify the best match. Aliases are possible to transform language codes into full locales. For example you can say if the code "en" is matched, the locale "en-US" will be used.
+The detector has a few options to tune the detection mechanism. First, there is a default locale. When every strategy sought for a locale, but did not find any, the default locale will be set. There is also a list of supported locales. Your application will probably not support every available locale, so you could define a set and SlmLocale tries to identify the best match. Mappings can be defined to transform language codes into full locales. For example you can say if the code "en" is matched, the locale "en-US" will be used.
 
 Usage
 ---
@@ -25,6 +25,14 @@ If you remove the `//` before the `'default'` line, you are able to set the defa
 If you only want to have a specified set of locales your application supports, you can remove the `//` before the `'supported'`. In the array you can specify the list you want to support. Keep in mind the order of the list is important. If a strategy can detect multiple locales (like with the HTTP Accept-Language header) the first match in the list will be chosen.
 
     'supported' => array('en-US', 'en-GB', 'en');
+
+### Locale mappings
+You can define locale mappings to use a specific locale when a different or more generic one is detected. Mappings are applied after detection but before the found event is triggered so strategies that perform post detection actions will receive the mapped locale corresponding to the detected one.
+
+    'mappings' => array(
+        'en' => 'en_US',
+        'fr' => 'fr_FR'
+    )
 
 ### Strategy configuration
 The strategies are configurable per strategy. You can also define the priority of the strategies used. By default, you can specify a string value for the strategy's name.

--- a/src/SlmLocale/Locale/Detector.php
+++ b/src/SlmLocale/Locale/Detector.php
@@ -168,7 +168,7 @@ class Detector implements EventManagerAwareInterface
         }
 
         if ($this->hasMappings() && array_key_exists($locale, $this->getMappings())) {
-        	$mappings = $this->getMappings();
+            $mappings = $this->getMappings();
             $locale   = $mappings[$locale];
         }
 

--- a/src/SlmLocale/Locale/Detector.php
+++ b/src/SlmLocale/Locale/Detector.php
@@ -71,6 +71,13 @@ class Detector implements EventManagerAwareInterface
      */
     protected $supported;
 
+    /**
+     * Optional list of locale mappings
+     *
+     * @var array
+     */
+    protected $mappings;
+
     public function getEventManager()
     {
         return $this->events;
@@ -119,6 +126,22 @@ class Detector implements EventManagerAwareInterface
         return (is_array($this->supported) && count($this->supported));
     }
 
+    public function getMappings()
+    {
+        return $this->mappings;
+    }
+
+    public function setMappings(array $mappings)
+    {
+        $this->mappings = $mappings;
+        return $this;
+    }
+
+    public function hasMappings()
+    {
+        return (is_array($this->mappings) && count($this->mappings));
+    }
+
     public function detect(RequestInterface $request, ResponseInterface $response = null)
     {
         $event = new LocaleEvent(LocaleEvent::EVENT_DETECT, $this);
@@ -142,6 +165,11 @@ class Detector implements EventManagerAwareInterface
 
         if ($this->hasSupported() && !in_array($locale, $this->getSupported())) {
             $locale = $this->getDefault();
+        }
+
+        if ($this->hasMappings() && array_key_exists($locale, $this->getMappings())) {
+        	$mappings = $this->getMappings();
+            $locale   = $mappings[$locale];
         }
 
         // Trigger FOUND event only when a response is given

--- a/src/SlmLocale/Service/DetectorFactory.php
+++ b/src/SlmLocale/Service/DetectorFactory.php
@@ -69,6 +69,10 @@ class DetectorFactory implements FactoryInterface
             $detector->setSupported($config['supported']);
         }
 
+        if (array_key_exists('mappings', $config)) {
+            $detector->setMappings($config['mappings']);
+        }
+
         return $detector;
     }
 

--- a/tests/SlmLocaleTest/Locale/DetectorTest.php
+++ b/tests/SlmLocaleTest/Locale/DetectorTest.php
@@ -166,6 +166,30 @@ class DetectorTest extends TestCase
         $this->assertFalse($detector->hasSupported());
     }
 
+    public function testUseMappedLocaleWhenMappingIsDefined()
+    {
+        $detector = new Detector;
+        $mappings = array('Foo' => 'Bar');
+        $detector->setMappings($mappings);
+
+        $self = $this;
+        $this->setEventManager($detector, LocaleEvent::EVENT_DETECT, function($e) {
+            return 'Foo';
+        });
+
+        $locale = $detector->detect(new Request, new Response);
+        $this->assertEquals('Bar', $locale);
+    }
+
+    public function testEmptyMappingsListIndicatesNoMappingsList()
+    {
+        $detector = new Detector;
+        $mappings = array();
+        $detector->setMappings($mappings);
+
+        $this->assertFalse($detector->hasMappings());
+    }
+
     public function testStrategyAttachesToEventManager()
     {
         $detector = new Detector;

--- a/tests/SlmLocaleTest/Service/DetectFactoryTest.php
+++ b/tests/SlmLocaleTest/Service/DetectFactoryTest.php
@@ -90,6 +90,24 @@ class DetectorFactoryTest extends TestCase
         $this->assertEquals(array('Foo', 'Bar'), $detector->getSupported());
     }
 
+    public function testLocaleMappingsAreOptional()
+    {
+        $sl = $this->getServiceLocator();
+        $detector = $sl->get('SlmLocale\Locale\Detector');
+
+        $this->assertNull($detector->getMappings());
+    }
+
+    public function testLocaleMappingsAreSet()
+    {
+        $sl = $this->getServiceLocator(array(
+            'mappings' => array('Foo' => 'Bar')
+        ));
+        $detector = $sl->get('SlmLocale\Locale\Detector');
+
+        $this->assertEquals(array('Foo' => 'Bar'), $detector->getMappings());
+    }
+
     public function testUseServiceLocatorToInstantiateStrategy()
     {
         $sl = $this->getServiceLocator(array(


### PR DESCRIPTION
Implemented feature described in [this comment](https://github.com/juriansluiman/SlmLocale/issues/42#issuecomment-32710818).

A set of mappings can be defined to map a detected locale or generic language to the one to actually use.

Most common use case is to support and detect a generic language (e.g. "en"), but have a specific locale be set (e.g. "en-US") for all locales that match the generic one.
