### PR TITLE
Fix ServiceLocator 2.x dependency injection for UriPathStrategy

### DIFF
--- a/src/SlmLocale/Strategy/Factory/UriPathStrategyFactory.php
+++ b/src/SlmLocale/Strategy/Factory/UriPathStrategyFactory.php
@@ -65,7 +65,7 @@ class UriPathStrategyFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
-        $strategy = new UriPathStrategy($container->get('router'));
+        $strategy = new UriPathStrategy($container->getServiceLocator()->get('router'));
         $strategy->setServiceLocator($container);
 
         return $strategy;

--- a/src/SlmLocale/Strategy/StrategyPluginManager.php
+++ b/src/SlmLocale/Strategy/StrategyPluginManager.php
@@ -42,6 +42,7 @@ namespace SlmLocale\Strategy;
 
 use Zend\ServiceManager\AbstractPluginManager;
 use Zend\ServiceManager\Factory\InvokableFactory;
+use SlmLocale\Strategy\Factory\UriPathStrategyFactory;
 
 class StrategyPluginManager extends AbstractPluginManager
 {
@@ -66,12 +67,12 @@ class StrategyPluginManager extends AbstractPluginManager
         HostStrategy::class                           => InvokableFactory::class,
         HttpAcceptLanguageStrategy::class             => InvokableFactory::class,
         QueryStrategy::class                          => InvokableFactory::class,
-        UriPathStrategy::class                        => InvokableFactory::class,
+        UriPathStrategy::class                        => UriPathStrategyFactory::class,
         'slmlocalestrategycookiestrategy'             => InvokableFactory::class,
         'slmlocalestrategyhoststrategy'               => InvokableFactory::class,
         'slmlocalestrategyhttpacceptlanguagestrategy' => InvokableFactory::class,
         'slmlocalestrategyquerystrategy'              => InvokableFactory::class,
-        'slmlocalestrategyuripathstrategy'            => InvokableFactory::class,
+        'slmlocalestrategyuripathstrategy'            => UriPathStrategyFactory::class,
     ];
 
     /**


### PR DESCRIPTION
Warning: I have not ran unit testing on this code!

Please review well, but it fixes issue #89 for me. I have no experience with zend-service-manager 3.0, but it works for me in 2.7.x

Hope this helps
