### PR TITLE
Fix issue #67 - New AssetStrategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ And enable some strategies. The naming is made via the following list:
  * **acceptlanguage**: `SlmLocale\Strategy\HttpAcceptLanguageStrategy`
  * **query**: `SlmLocale\Strategy\QueryStrategy`
  * **uripath**: `SlmLocale\Strategy\UriPathStrategy`
+ * **asset**: `SlmLocale\Strategy\AssetStrategy`
 
 You can enable one or more of them in the `strategies` list. Mind the priority
 is important! You usually want the `acceptlanguage` as last for a fallback:

--- a/docs/2.Strategies.md
+++ b/docs/2.Strategies.md
@@ -58,3 +58,35 @@ To map TLDs to locales, use the aliases array.
     ],
 ],
 ```
+
+Asset strategy - to prevent URIs of assets being rewritten
+---
+If you use an Asset Manager (f. e. https://github.com/RWOverdijk/AssetManager) you may face the problem of URIs of your assets getting rewritten to a locale-dependent URI (f. e. `http://example.com/de/css/style.css`). Depending how your webserver is configured, this leads to 404 errors.
+
+To cope with such problems use AssetStrategy:
+```
+'strategies' => [
+    [
+        'name' => SlmLocale\Strategy\AssetStrategy::class,
+        'options' => [
+            'file_extensions' => [
+                'css', 'js'
+            ]
+        ]
+    ],
+    'query',
+    [
+        'name' => \SlmLocale\Strategy\UriPathStrategy::class,
+        'options' => [
+            'redirect_when_found' => true,
+            'aliases' => array('de' => 'de_DE', 'en' => 'en_GB'),
+        ]
+    ],
+    'cookie',
+    'acceptlanguage'
+],
+```
+
+The `file_extensions` array should contain all file endings you use for your assets. URIs of files which have one of the specified extensions will not be rewritten (the example above excludes `css` and `js` files).
+
+**Important:** Make sure to add AssetStrategy first / have AssetStrategy added with highest priority in your config. Otherwise some other strategies may rewrite the URI of an asset.

--- a/src/SlmLocale/Locale/Detector.php
+++ b/src/SlmLocale/Locale/Detector.php
@@ -191,7 +191,7 @@ class Detector implements EventManagerAwareInterface
             $events->triggerEventUntil(function ($r) use (&$return) {
                 if ($r instanceof ResponseInterface) {
                     $return = true;
-                } else if ($r === false) {
+                } elseif ($r === false) {
                     // return true, if a previous listener returned false. So we can stop processing further listeners. This is needed for AssetStrategy to prevent redirects.
                     return true;
                 }

--- a/src/SlmLocale/Locale/Detector.php
+++ b/src/SlmLocale/Locale/Detector.php
@@ -191,6 +191,9 @@ class Detector implements EventManagerAwareInterface
             $events->triggerEventUntil(function ($r) use (&$return) {
                 if ($r instanceof ResponseInterface) {
                     $return = true;
+                } else if ($r === false) {
+                    // return true, if a previous listener returned false. So we can stop processing further listeners. This is needed for AssetStrategy to prevent redirects.
+                    return true;
                 }
             }, $event);
 

--- a/src/SlmLocale/Strategy/AssetStrategy.php
+++ b/src/SlmLocale/Strategy/AssetStrategy.php
@@ -1,6 +1,6 @@
 <?php
-namespace SlmLocale\Strategy;
 
+namespace SlmLocale\Strategy;
 
 use SlmLocale\LocaleEvent;
 
@@ -18,14 +18,13 @@ class AssetStrategy extends AbstractStrategy
 
     public function detect(LocaleEvent $event)
     {
-        return;
+        return null;
     }
 
     public function found(LocaleEvent $event)
     {
-        $path = $event->getRequest()->getUri();
-        $path = parse_url($path, PHP_URL_PATH);
-        $extension = pathinfo($path, PATHINFO_EXTENSION);
+        $path      = $event->getRequest()->getUri();
+        $extension = parse_url($path, PHP_URL_PATH);
 
         // if the file extension of the uri is found within the configured file_extensions, we do not rewrite and skip further processing
         if (in_array($extension, $this->file_extensions)) {
@@ -39,5 +38,4 @@ class AssetStrategy extends AbstractStrategy
             $this->file_extensions = (array) $options['file_extensions'];
         }
     }
-
 }

--- a/src/SlmLocale/Strategy/AssetStrategy.php
+++ b/src/SlmLocale/Strategy/AssetStrategy.php
@@ -27,7 +27,7 @@ class AssetStrategy extends AbstractStrategy
         $path = parse_url($path, PHP_URL_PATH);
         $extension = pathinfo($path, PATHINFO_EXTENSION);
 
-        // if the file extension is found within the uri, we do not rewrite and skip further processing
+        // if the file extension of the uri is found within the configured file_extensions, we do not rewrite and skip further processing
         if (in_array($extension, $this->file_extensions)) {
             return false;
         }

--- a/src/SlmLocale/Strategy/AssetStrategy.php
+++ b/src/SlmLocale/Strategy/AssetStrategy.php
@@ -24,7 +24,8 @@ class AssetStrategy extends AbstractStrategy
     public function found(LocaleEvent $event)
     {
         $path      = $event->getRequest()->getUri();
-        $extension = parse_url($path, PHP_URL_PATH);
+        $path      = parse_url($path, PHP_URL_PATH);
+        $extension = pathinfo($path, PATHINFO_EXTENSION);
 
         // if the file extension of the uri is found within the configured file_extensions, we do not rewrite and skip further processing
         if (in_array($extension, $this->file_extensions)) {

--- a/src/SlmLocale/Strategy/AssetStrategy.php
+++ b/src/SlmLocale/Strategy/AssetStrategy.php
@@ -1,16 +1,16 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: mfuesslin
- * Date: 07.11.17
- * Time: 11:18
- */
-
 namespace SlmLocale\Strategy;
 
 
 use SlmLocale\LocaleEvent;
 
+/**
+ * This class checks whether the requested uri should deliver an asset and should therefore not be redirected.
+ * If it is an asset, we return false to stop further processing of other strategies in SlmLocale\Locale\Detector.
+ *
+ * Class AssetStrategy
+ * @package SlmLocale\Strategy
+ */
 class AssetStrategy extends AbstractStrategy
 {
     /** @var  array */

--- a/src/SlmLocale/Strategy/AssetStrategy.php
+++ b/src/SlmLocale/Strategy/AssetStrategy.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: mfuesslin
+ * Date: 07.11.17
+ * Time: 11:18
+ */
+
+namespace SlmLocale\Strategy;
+
+
+use SlmLocale\LocaleEvent;
+
+class AssetStrategy extends AbstractStrategy
+{
+    /** @var  array */
+    protected $file_extensions;
+
+    public function found(LocaleEvent $event)
+    {
+        $path = $event->getUri()->getPath();
+        $extension = pathinfo($path, PATHINFO_EXTENSION);
+
+        // if the file extension is found within the uri, we do not rewrite and skip further processing
+        if (in_array($extension, $this->file_extensions)) {
+            return;
+        }
+    }
+
+    public function setOptions(array $options = [])
+    {
+        if (array_key_exists('file_extensions', $options)) {
+            $this->file_extensions = (array) $options['file_extensions'];
+        }
+    }
+
+}

--- a/src/SlmLocale/Strategy/AssetStrategy.php
+++ b/src/SlmLocale/Strategy/AssetStrategy.php
@@ -18,7 +18,7 @@ class AssetStrategy extends AbstractStrategy
 
     public function detect(LocaleEvent $event)
     {
-        return \Locale::getDefault();
+        return;
     }
 
     public function found(LocaleEvent $event)

--- a/src/SlmLocale/Strategy/AssetStrategy.php
+++ b/src/SlmLocale/Strategy/AssetStrategy.php
@@ -8,24 +8,44 @@ use SlmLocale\LocaleEvent;
  * This class checks whether the requested uri should deliver an asset and should therefore not be redirected.
  * If it is an asset, we return false to stop further processing of other strategies in SlmLocale\Locale\Detector.
  *
+ * Example config:
+ * 'slm_locale' => [
+ *     'default' => 'de_DE',
+ *     'supported' => ['en_GB', 'de_DE'],
+ *     'strategies' => [
+ *         [
+ *             'name' => SlmLocale\Strategy\AssetStrategy::class,
+ *             'options' => [
+ *                 'file_extensions' => [
+ *                     'css', 'js'
+ *                 ]
+ *             ]
+ *         ],
+ *         'query',
+ *         'cookie',
+ *         'acceptlanguage'
+ *     ],
+ *     'mappings' => [
+ *         'en' => 'en_GB',
+ *         'de' => 'de_DE',
+ *     ]
+ * ],
+ *
+ * This example config would ignore the file_extensions ".css", ".CSS", ".js", ".JS".
+ *
  * Class AssetStrategy
  * @package SlmLocale\Strategy
  */
 class AssetStrategy extends AbstractStrategy
 {
     /** @var  array */
-    protected $file_extensions;
-
-    public function detect(LocaleEvent $event)
-    {
-        return null;
-    }
+    protected $file_extensions = [];
 
     public function found(LocaleEvent $event)
     {
         $path      = $event->getRequest()->getUri();
         $path      = parse_url($path, PHP_URL_PATH);
-        $extension = pathinfo($path, PATHINFO_EXTENSION);
+        $extension = strtolower(pathinfo($path, PATHINFO_EXTENSION));
 
         // if the file extension of the uri is found within the configured file_extensions, we do not rewrite and skip further processing
         if (in_array($extension, $this->file_extensions)) {

--- a/src/SlmLocale/Strategy/AssetStrategy.php
+++ b/src/SlmLocale/Strategy/AssetStrategy.php
@@ -16,14 +16,20 @@ class AssetStrategy extends AbstractStrategy
     /** @var  array */
     protected $file_extensions;
 
+    public function detect(LocaleEvent $event)
+    {
+        return \Locale::getDefault();
+    }
+
     public function found(LocaleEvent $event)
     {
-        $path = $event->getUri()->getPath();
+        $path = $event->getRequest()->getUri();
+        $path = parse_url($path, PHP_URL_PATH);
         $extension = pathinfo($path, PATHINFO_EXTENSION);
 
         // if the file extension is found within the uri, we do not rewrite and skip further processing
         if (in_array($extension, $this->file_extensions)) {
-            return;
+            return false;
         }
     }
 

--- a/src/SlmLocale/Strategy/StrategyPluginManager.php
+++ b/src/SlmLocale/Strategy/StrategyPluginManager.php
@@ -57,6 +57,7 @@ class StrategyPluginManager extends AbstractPluginManager
         'acceptlanguage' => HttpAcceptLanguageStrategy::class,
         'query'          => QueryStrategy::class,
         'uripath'        => UriPathStrategy::class,
+        'asset'          => AssetStrategy::class
     ];
 
     /**
@@ -68,11 +69,13 @@ class StrategyPluginManager extends AbstractPluginManager
         HttpAcceptLanguageStrategy::class             => InvokableFactory::class,
         QueryStrategy::class                          => InvokableFactory::class,
         UriPathStrategy::class                        => UriPathStrategyFactory::class,
+        AssetStrategy::class                          => InvokableFactory::class,
         'slmlocalestrategycookiestrategy'             => InvokableFactory::class,
         'slmlocalestrategyhoststrategy'               => InvokableFactory::class,
         'slmlocalestrategyhttpacceptlanguagestrategy' => InvokableFactory::class,
         'slmlocalestrategyquerystrategy'              => InvokableFactory::class,
         'slmlocalestrategyuripathstrategy'            => UriPathStrategyFactory::class,
+        'slmlocalestrategyassetstrategy'              => InvokableFactory::class
     ];
 
     /**

--- a/src/SlmLocale/Strategy/StrategyPluginManager.php
+++ b/src/SlmLocale/Strategy/StrategyPluginManager.php
@@ -57,7 +57,7 @@ class StrategyPluginManager extends AbstractPluginManager
         'acceptlanguage' => HttpAcceptLanguageStrategy::class,
         'query'          => QueryStrategy::class,
         'uripath'        => UriPathStrategy::class,
-        'asset'          => AssetStrategy::class
+        'asset'          => AssetStrategy::class,
     ];
 
     /**
@@ -75,7 +75,7 @@ class StrategyPluginManager extends AbstractPluginManager
         'slmlocalestrategyhttpacceptlanguagestrategy' => InvokableFactory::class,
         'slmlocalestrategyquerystrategy'              => InvokableFactory::class,
         'slmlocalestrategyuripathstrategy'            => UriPathStrategyFactory::class,
-        'slmlocalestrategyassetstrategy'              => InvokableFactory::class
+        'slmlocalestrategyassetstrategy'              => InvokableFactory::class,
     ];
 
     /**

--- a/tests/SlmLocaleTest/Strategy/AssetStrategyTest.php
+++ b/tests/SlmLocaleTest/Strategy/AssetStrategyTest.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: mfuesslin
- * Date: 07.11.17
- * Time: 17:14
- */
 
 namespace SlmLocaleTest\Strategy;
 

--- a/tests/SlmLocaleTest/Strategy/AssetStrategyTest.php
+++ b/tests/SlmLocaleTest/Strategy/AssetStrategyTest.php
@@ -11,11 +11,10 @@ namespace SlmLocaleTest\Strategy;
 use PHPUnit_Framework_TestCase as TestCase;
 use SlmLocale\LocaleEvent;
 use SlmLocale\Strategy\AssetStrategy;
-use Zend\Http\PhpEnvironment\Request as HttpRequest;
-use Zend\Mvc\Router\Http\TreeRouteStack as HttpRouter;
-use Zend\Http\PhpEnvironment\Response as HttpResponse;
 use Zend\Console\Request as ConsoleRequest;
 use Zend\Console\Response as ConsoleResponse;
+use Zend\Http\PhpEnvironment\Request as HttpRequest;
+use Zend\Http\PhpEnvironment\Response as HttpResponse;
 
 class AssetStrategyTest extends TestCase
 {

--- a/tests/SlmLocaleTest/Strategy/AssetStrategyTest.php
+++ b/tests/SlmLocaleTest/Strategy/AssetStrategyTest.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: mfuesslin
+ * Date: 07.11.17
+ * Time: 17:14
+ */
+
+namespace SlmLocaleTest\Strategy;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use SlmLocale\LocaleEvent;
+use SlmLocale\Strategy\AssetStrategy;
+use Zend\Http\PhpEnvironment\Request as HttpRequest;
+use Zend\Mvc\Router\Http\TreeRouteStack as HttpRouter;
+use Zend\Http\PhpEnvironment\Response as HttpResponse;
+use Zend\Console\Request as ConsoleRequest;
+use Zend\Console\Response as ConsoleResponse;
+
+class AssetStrategyTest extends TestCase
+{
+    /** @var AssetStrategy */
+    private $strategy;
+
+    /** @var LocaleEvent */
+    private $event;
+
+    public function setup()
+    {
+        $this->strategy = new AssetStrategy();
+        $this->strategy->setOptions(['file_extensions' => ['css', 'js']]);
+
+        $this->event = new LocaleEvent();
+        $this->event->setSupported(['nl', 'de', 'en']);
+    }
+
+    public function testDetectReturnsNullByDefault()
+    {
+        $this->event->setRequest(new HttpRequest());
+        $this->event->setResponse(new HttpResponse());
+
+        $locale = $this->strategy->detect($this->event);
+        $this->assertNull($locale);
+    }
+
+    public function testDetectWithConsoleRequestReturnsNull()
+    {
+        $this->event->setRequest(new ConsoleRequest());
+        $this->event->setResponse(new ConsoleResponse());
+
+        $locale = $this->strategy->detect($this->event);
+        $this->assertNull($locale);
+    }
+
+    public function testFoundShouldReturnFalseIfFileExtensionWasConfigured()
+    {
+        $request = new HttpRequest();
+        $request->setUri('http://example.com/css/style.css');
+
+        $this->event->setRequest($request);
+
+        // should be false if extension was configured to ignore.
+        $result = $this->strategy->found($this->event);
+        $this->assertFalse($result);
+
+        $request = new HttpRequest();
+        $request->setUri('http://example.com/css/style.css?ver=123456');
+
+        $this->event->setRequest($request);
+
+        // should be false if extension was configured to ignore.
+        $result = $this->strategy->found($this->event);
+        $this->assertFalse($result);
+
+        $request = new HttpRequest();
+        $request->setUri('http://example.com/css/script.js');
+
+        $this->event->setRequest($request);
+
+        // should be false if extension was configured to ignore.
+        $result = $this->strategy->found($this->event);
+        $this->assertFalse($result);
+
+        $request = new HttpRequest();
+        $request->setUri('http://example.com/image/image.jpg');
+
+        $this->event->setRequest($request);
+
+        // should be null if extension was NOT configured to ignore (the next strategy will take care of locale extraction).
+        $result = $this->strategy->found($this->event);
+        $this->assertNull($result);
+    }
+}


### PR DESCRIPTION
Fixing problems of issue #67, which describes problems by using SlmLocale in combination with the famous https://github.com/RWOverdijk/AssetManager module.

# Problem
When using asset manager to manage assets in your project, uris of assets getting rewritten to locale aware uris. This leads to 404 not found, because the assetmanager is not able to resolve them anymore. Therefore we need a strategy to cope such uris.

# Solution
The provided AssetStrategy checks if the requested uri is an asset and prevents url rewriting through other strategies.

## Example config
```
return [
    'slm_locale' => [
        'default' => 'de_DE',

        'supported' => ['en_GB', 'de_DE'],

        'strategies' => [
           [
                'name' => SlmLocale\Strategy\AssetStrategy::class,
                'options' => [
                    'file_extensions' => [
                        'css', 'js'
                    ]
                ]
            ],
            'query',
            [
                'name' => \SlmLocale\Strategy\UriPathStrategy::class,
                'options' => [
                    'redirect_when_found' => true,
                    'aliases' => array('de' => 'de_DE', 'en' => 'en_GB'),
                ]
            ],
            'cookie',
            'acceptlanguage'
        ],

        'mappings' => [
            'en' => 'en_GB',
            'de' => 'de_DE',
        ]
    ],
];
```