### PR TITLE
Feature/phpunit via strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,32 +113,8 @@ Inject the detected language here with the following code:
 <html lang="<?= Locale::getPrimaryLanguage(Locale::getDefault())?>">
 ```
 
-### Disable UriPathStrategy in PHPUNIT
-This is necessary (at the moment) if you want to use ``this->dispatch('my/uri');`` in your `AbstractHttpControllerTestCase` unit tests.
-Otherwise, if you check for responseCode you will get `302` where it should be `200`.
-
-Example:
-```
-$this->dispatch('/to/my/uri');
-$this->assertResponseStatusCode(200); // this will be 302 instead of 200
-
-$this->dispatch('/en/to/my/uri');
-$this->assertResponseStatusCode(200); // this will be 302 instead of 200
-```
-
-To fix add the following to your phpunit config.
-
-phpunit.xml:
-```
-<phpunit...>
-    ...
-    <php>
-        <server name="DISABLE_URIPATHSTRATEGY" value="true" />
-    </php>
-</phpunit>
-```
-
-Or set ``$_SERVER['DISABLE_URIPATHSTRATEGY'] = true;`` in your bootstrap file of phpunit. 
+### PHPUNIT configuration (as this module breaks some tests at the moment)
+Have a look at [strategies documentation](docs/2.Strategies.md).
 
 ### Create a list of available locales
 

--- a/docs/2.Strategies.md
+++ b/docs/2.Strategies.md
@@ -90,3 +90,58 @@ To cope with such problems use AssetStrategy:
 The `file_extensions` array should contain all file endings you use for your assets. URIs of files which have one of the specified extensions will not be rewritten (the example above excludes `css` and `js` files).
 
 **Important:** Make sure to add AssetStrategy first / have AssetStrategy added with highest priority in your config. Otherwise some other strategies may rewrite the URI of an asset.
+
+### PHPUNIT strategy
+This is necessary (at the moment) if you want to use ``this->dispatch('my/uri');`` in your `AbstractHttpControllerTestCase` unit tests.
+Otherwise, if you check for responseCode you will get `302` where it should be `200`.
+More information at: https://github.com/basz/SlmLocale/issues/26
+
+Example:
+```
+$this->dispatch('/to/my/uri');
+$this->assertResponseStatusCode(200); // this will be 302 instead of 200
+
+$this->dispatch('/en/to/my/uri');
+$this->assertResponseStatusCode(200); // this will be 302 instead of 200
+```
+
+To fix add the following to your phpunit config.
+
+phpunit.xml:
+```
+<phpunit...>
+    ...
+    <php>
+        <server name="DISABLE_STRATEGIES" value="true" />
+    </php>
+</phpunit>
+```
+
+Or set ``$_SERVER['DISABLE_STRATEGIES'] = true;`` in your bootstrap file of phpunit.
+
+Do not forget to enable phpunit strategy in config (example):
+
+```
+'strategies' => [
+    'phpunit',
+    [
+        'name' => SlmLocale\Strategy\AssetStrategy::class,
+        'options' => [
+            'file_extensions' => [
+                'css', 'js'
+            ]
+        ]
+    ],
+    'query',
+    [
+        'name' => \SlmLocale\Strategy\UriPathStrategy::class,
+        'options' => [
+            'redirect_when_found' => true,
+            'aliases' => array('de' => 'de_DE', 'en' => 'en_GB'),
+        ]
+    ],
+    'cookie',
+    'acceptlanguage'
+],
+``` 
+**Important:** Make sure to add PhpunitStrategy first / have PhpunitStrategy added with highest priority in your config. Otherwise some other strategies may rewrite the URI of an asset.

--- a/docs/2.Strategies.md
+++ b/docs/2.Strategies.md
@@ -112,12 +112,12 @@ phpunit.xml:
 <phpunit...>
     ...
     <php>
-        <server name="DISABLE_STRATEGIES" value="true" />
+        <server name="SLMLOCALE_DISABLE_STRATEGIES" value="true" />
     </php>
 </phpunit>
 ```
 
-Or set ``$_SERVER['DISABLE_STRATEGIES'] = true;`` in your bootstrap file of phpunit.
+Or set ``$_SERVER['SLMLOCALE_DISABLE_STRATEGIES'] = true;`` in your bootstrap file of phpunit.
 
 Do not forget to enable phpunit strategy in config (example):
 

--- a/src/SlmLocale/Strategy/PhpunitStrategy.php
+++ b/src/SlmLocale/Strategy/PhpunitStrategy.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace SlmLocale\Strategy;
+
+use SlmLocale\LocaleEvent;
+
+/**
+ * This class checks whether the requested uri should deliver an asset and should therefore not be redirected.
+ * If it is an asset, we return false to stop further processing of other strategies in SlmLocale\Locale\Detector.
+ *
+ * Example config:
+ * 'slm_locale' => [
+ *     'default' => 'de_DE',
+ *     'supported' => ['en_GB', 'de_DE'],
+ *     'strategies' => [
+ *         [
+ *             'name' => SlmLocale\Strategy\AssetStrategy::class,
+ *             'options' => [
+ *                 'file_extensions' => [
+ *                     'css', 'js'
+ *                 ]
+ *             ]
+ *         ],
+ *         'query',
+ *         'cookie',
+ *         'acceptlanguage'
+ *     ],
+ *     'mappings' => [
+ *         'en' => 'en_GB',
+ *         'de' => 'de_DE',
+ *     ]
+ * ],
+ *
+ * This example config would ignore the file_extensions ".css", ".CSS", ".js", ".JS".
+ *
+ * Class PhpunitStrategy
+ * @package SlmLocale\Strategy
+ */
+final class PhpunitStrategy extends AbstractStrategy
+{
+    /** @var  array */
+    private $file_extensions = [];
+
+    public function detect(LocaleEvent $event)
+    {
+        $this->stopPropagationIfPhpunit($event);
+    }
+
+    public function found(LocaleEvent $event)
+    {
+        $this->stopPropagationIfPhpunit($event);
+    }
+
+    private function stopPropagationIfPhpunit(LocaleEvent $event)
+    {
+        if (! $this->isHttpRequest($event->getRequest())) {
+            return;
+        }
+
+        $isPhpunit = array_key_exists('DISABLE_URIPATHSTRATEGY', $_SERVER) && $_SERVER['DISABLE_URIPATHSTRATEGY'];
+
+        // if the file extension of the uri is found within the configured file_extensions, we do not rewrite and skip further processing
+        if ($isPhpunit) {
+            $event->stopPropagation();
+        }
+    }
+}

--- a/src/SlmLocale/Strategy/PhpunitStrategy.php
+++ b/src/SlmLocale/Strategy/PhpunitStrategy.php
@@ -5,33 +5,10 @@ namespace SlmLocale\Strategy;
 use SlmLocale\LocaleEvent;
 
 /**
- * This class checks whether the requested uri should deliver an asset and should therefore not be redirected.
- * If it is an asset, we return false to stop further processing of other strategies in SlmLocale\Locale\Detector.
+ * This class checks if running in a phpunit environment. If so and phpunit is correctly configured, it will stop event processing as we cannot properly use this module with phpunit tests at the moment.
+ * @SEE https://github.com/basz/SlmLocale/pull/99
  *
- * Example config:
- * 'slm_locale' => [
- *     'default' => 'de_DE',
- *     'supported' => ['en_GB', 'de_DE'],
- *     'strategies' => [
- *         [
- *             'name' => SlmLocale\Strategy\AssetStrategy::class,
- *             'options' => [
- *                 'file_extensions' => [
- *                     'css', 'js'
- *                 ]
- *             ]
- *         ],
- *         'query',
- *         'cookie',
- *         'acceptlanguage'
- *     ],
- *     'mappings' => [
- *         'en' => 'en_GB',
- *         'de' => 'de_DE',
- *     ]
- * ],
- *
- * This example config would ignore the file_extensions ".css", ".CSS", ".js", ".JS".
+ * For configuration example have a look at README.md.
  *
  * Class PhpunitStrategy
  * @package SlmLocale\Strategy
@@ -57,7 +34,7 @@ final class PhpunitStrategy extends AbstractStrategy
             return;
         }
 
-        $isPhpunit = array_key_exists('DISABLE_URIPATHSTRATEGY', $_SERVER) && $_SERVER['DISABLE_URIPATHSTRATEGY'];
+        $isPhpunit = array_key_exists('DISABLE_STRATEGIES', $_SERVER) && $_SERVER['DISABLE_STRATEGIES'];
 
         // if the file extension of the uri is found within the configured file_extensions, we do not rewrite and skip further processing
         if ($isPhpunit) {

--- a/src/SlmLocale/Strategy/PhpunitStrategy.php
+++ b/src/SlmLocale/Strategy/PhpunitStrategy.php
@@ -34,7 +34,7 @@ final class PhpunitStrategy extends AbstractStrategy
             return;
         }
 
-        $isPhpunit = array_key_exists('DISABLE_STRATEGIES', $_SERVER) && $_SERVER['DISABLE_STRATEGIES'];
+        $isPhpunit = array_key_exists('SLMLOCALE_DISABLE_STRATEGIES', $_SERVER) && $_SERVER['SLMLOCALE_DISABLE_STRATEGIES'];
 
         // if the file extension of the uri is found within the configured file_extensions, we do not rewrite and skip further processing
         if ($isPhpunit) {

--- a/src/SlmLocale/Strategy/StrategyPluginManager.php
+++ b/src/SlmLocale/Strategy/StrategyPluginManager.php
@@ -58,6 +58,7 @@ class StrategyPluginManager extends AbstractPluginManager
         'query'          => QueryStrategy::class,
         'uripath'        => UriPathStrategy::class,
         'asset'          => AssetStrategy::class,
+        'phpunit'        => PhpunitStrategy::class,
     ];
 
     /**
@@ -70,5 +71,6 @@ class StrategyPluginManager extends AbstractPluginManager
         QueryStrategy::class              => InvokableFactory::class,
         UriPathStrategy::class            => UriPathStrategyFactory::class,
         AssetStrategy::class              => InvokableFactory::class,
+        PhpunitStrategy::class            => InvokableFactory::class,
     ];
 }

--- a/src/SlmLocale/Strategy/UriPathStrategy.php
+++ b/src/SlmLocale/Strategy/UriPathStrategy.php
@@ -118,10 +118,6 @@ class UriPathStrategy extends AbstractStrategy
 
     public function found(LocaleEvent $event)
     {
-        if (array_key_exists('DISABLE_URIPATHSTRATEGY', $_SERVER) && true === $_SERVER['DISABLE_URIPATHSTRATEGY']) {
-            return;
-        }
-
         $request = $event->getRequest();
         if (! $this->isHttpRequest($request)) {
             return;

--- a/tests/SlmLocaleTest/Strategy/PhpunitStrategyTest.php
+++ b/tests/SlmLocaleTest/Strategy/PhpunitStrategyTest.php
@@ -11,14 +11,13 @@ namespace SlmLocaleTest\Strategy;
 use PHPUnit\Framework\TestCase;
 use SlmLocale\LocaleEvent;
 use SlmLocale\Strategy\PhpunitStrategy;
-use SlmLocale\Strategy\UriPathStrategy;
 use Zend\Http\PhpEnvironment\Request as HttpRequest;
 use Zend\Http\PhpEnvironment\Response as HttpResponse;
 use Zend\Router\Http\TreeRouteStack as HttpRouter;
 
 class PhpunitStrategyTest extends TestCase
 {
-    /** @var UriPathStrategy */
+    /** @var PhpunitStrategy */
     private $strategy;
     /** @var LocaleEvent */
     private $event;
@@ -30,28 +29,28 @@ class PhpunitStrategyTest extends TestCase
         $this->router = new HttpRouter();
 
         $this->strategy = new PhpunitStrategy();
-
-        $this->event = new LocaleEvent();
-        $this->event->setSupported(['nl', 'de', 'en']);
     }
 
-    public function testDisableUriPathStrategyPhpunit()
+    public function testPreventStrategiesExecutionIfPhpunit()
     {
-        $_SERVER['DISABLE_URIPATHSTRATEGY'] = true;
+        $_SERVER['DISABLE_STRATEGIES'] = true;
+
+        $event = new LocaleEvent();
+        $event->setSupported(['nl', 'de', 'en']);
 
         $uri     = 'http://username:password@example.com:8080/some/deep/path/some.file?withsomeparam=true';
         $request = new HttpRequest();
         $request->setUri($uri);
 
-        $this->event->setLocale('en');
-        $this->event->setRequest($request);
-        $this->event->setResponse(new HttpResponse());
+        $event->setLocale('en');
+        $event->setRequest($request);
+        $event->setResponse(new HttpResponse());
 
-        $this->strategy->found($this->event);
+        $this->strategy->found($event);
 
-        $statusCode = $this->event->getResponse()->getStatusCode();
+        $statusCode = $event->getResponse()->getStatusCode();
         $this->assertEquals(200, $statusCode);
 
-        $_SERVER['DISABLE_URIPATHSTRATEGY'] = false;
+        $_SERVER['DISABLE_STRATEGIES'] = false;
     }
 }

--- a/tests/SlmLocaleTest/Strategy/PhpunitStrategyTest.php
+++ b/tests/SlmLocaleTest/Strategy/PhpunitStrategyTest.php
@@ -33,7 +33,7 @@ class PhpunitStrategyTest extends TestCase
 
     public function testPreventStrategiesExecutionIfPhpunit()
     {
-        $_SERVER['DISABLE_STRATEGIES'] = true;
+        $_SERVER['SLMLOCALE_DISABLE_STRATEGIES'] = true;
 
         $event = new LocaleEvent();
         $event->setSupported(['nl', 'de', 'en']);
@@ -51,6 +51,6 @@ class PhpunitStrategyTest extends TestCase
         $statusCode = $event->getResponse()->getStatusCode();
         $this->assertEquals(200, $statusCode);
 
-        $_SERVER['DISABLE_STRATEGIES'] = false;
+        $_SERVER['SLMLOCALE_DISABLE_STRATEGIES'] = false;
     }
 }

--- a/tests/SlmLocaleTest/Strategy/PhpunitStrategyTest.php
+++ b/tests/SlmLocaleTest/Strategy/PhpunitStrategyTest.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: mfuesslin
+ * Date: 12.12.17
+ * Time: 16:15
+ */
+
+namespace SlmLocaleTest\Strategy;
+
+use PHPUnit\Framework\TestCase;
+use SlmLocale\LocaleEvent;
+use SlmLocale\Strategy\PhpunitStrategy;
+use SlmLocale\Strategy\UriPathStrategy;
+use Zend\Http\PhpEnvironment\Request as HttpRequest;
+use Zend\Http\PhpEnvironment\Response as HttpResponse;
+use Zend\Router\Http\TreeRouteStack as HttpRouter;
+
+class PhpunitStrategyTest extends TestCase
+{
+    /** @var UriPathStrategy */
+    private $strategy;
+    /** @var LocaleEvent */
+    private $event;
+    /** @var HttpRouter */
+    private $router;
+
+    public function setup()
+    {
+        $this->router = new HttpRouter();
+
+        $this->strategy = new PhpunitStrategy();
+
+        $this->event = new LocaleEvent();
+        $this->event->setSupported(['nl', 'de', 'en']);
+    }
+
+    public function testDisableUriPathStrategyPhpunit()
+    {
+        $_SERVER['DISABLE_URIPATHSTRATEGY'] = true;
+
+        $uri     = 'http://username:password@example.com:8080/some/deep/path/some.file?withsomeparam=true';
+        $request = new HttpRequest();
+        $request->setUri($uri);
+
+        $this->event->setLocale('en');
+        $this->event->setRequest($request);
+        $this->event->setResponse(new HttpResponse());
+
+        $this->strategy->found($this->event);
+
+        $statusCode = $this->event->getResponse()->getStatusCode();
+        $this->assertEquals(200, $statusCode);
+
+        $_SERVER['DISABLE_URIPATHSTRATEGY'] = false;
+    }
+}

--- a/tests/SlmLocaleTest/Strategy/UriPathStrategyTest.php
+++ b/tests/SlmLocaleTest/Strategy/UriPathStrategyTest.php
@@ -348,28 +348,6 @@ class UriPathStrategyTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function testDisableUriPathStrategyPhpunit()
-    {
-        $_SERVER['DISABLE_URIPATHSTRATEGY'] = true;
-
-        $uri     = 'http://username:password@example.com:8080/some/deep/path/some.file?withsomeparam=true';
-        $request = new HttpRequest();
-        $request->setUri($uri);
-
-        $this->event->setLocale('en');
-        $this->event->setRequest($request);
-        $this->event->setResponse(new HttpResponse());
-
-        $this->strategy->found($this->event);
-
-        $statusCode = $this->event->getResponse()->getStatusCode();
-        $header     = $this->event->getResponse()->getHeaders()->get('Location');
-        $expected   = 'Location: http://username:password@example.com:8080/en/some/deep/path/some.file?withsomeparam=true';
-        $this->assertEquals(200, $statusCode);
-
-        $_SERVER['DISABLE_URIPATHSTRATEGY'] = false;
-    }
-
     protected function getPluginManager($console = false)
     {
         $sl = new ServiceManager();


### PR DESCRIPTION
fix #26 .
Added PhpunitStrategy to cope with problems while unit testing zend applications. Updated README also with example code.
Sadly we need a special PHPUNIT variable set in phpunit.xml or boostrap.php file of the unit tests:
`SLMLOCALE_DISABLE_STRATEGIES` has to be set to `true`. Otherwise we cannot differentiate between application was run by console command or phpunit command.