### PR TITLE
 fix locale url change, from default locale to other locale

### DIFF
--- a/src/SlmLocale/Strategy/UriPathStrategy.php
+++ b/src/SlmLocale/Strategy/UriPathStrategy.php
@@ -194,7 +194,7 @@ class UriPathStrategy extends AbstractStrategy
         $path = $uri->getPath();
 
         // Last part of base is now always locale, remove that
-        $parts = explode('/', trim($base, '/'));
+        $parts       = explode('/', trim($base, '/'));
         $lastElement = count($parts) - 1;
 
         $removeFirstLocale = true;

--- a/src/SlmLocale/Strategy/UriPathStrategy.php
+++ b/src/SlmLocale/Strategy/UriPathStrategy.php
@@ -205,7 +205,7 @@ class UriPathStrategy extends AbstractStrategy
         $removeFirstLocale = true;
         if (null !== $this->default &&
             isset($parts[0]) &&
-            !in_array($parts[0], $event->getSupported(), true) &&
+            ! in_array($parts[0], $event->getSupported(), true) &&
             $parts[0] !== $this->default
         ) {
             $removeFirstLocale = false;

--- a/src/SlmLocale/Strategy/UriPathStrategy.php
+++ b/src/SlmLocale/Strategy/UriPathStrategy.php
@@ -216,7 +216,6 @@ class UriPathStrategy extends AbstractStrategy
             array_shift($parts);
         }
 
-
         if ($locale === $this->default) {
             $locale = '';
         } else {

--- a/src/SlmLocale/Strategy/UriPathStrategy.php
+++ b/src/SlmLocale/Strategy/UriPathStrategy.php
@@ -235,25 +235,6 @@ class UriPathStrategy extends AbstractStrategy
         return $uri;
     }
 
-    /**
-     * @return SimpleRouteStack
-     */
-    public function getRouter()
-    {
-        return $this->router;
-    }
-
-    /**
-     * @param SimpleRouteStack $router
-     * @return $this
-     */
-    public function setRouter($router)
-    {
-        $this->router = $router;
-
-        return $this;
-    }
-
     protected function getFirstSegmentInPath(Uri $uri, $base = null)
     {
         $path = $uri->getPath();

--- a/src/SlmLocale/Strategy/UriPathStrategy.php
+++ b/src/SlmLocale/Strategy/UriPathStrategy.php
@@ -198,8 +198,20 @@ class UriPathStrategy extends AbstractStrategy
         }
         $parts  = explode('/', trim($path, '/'));
 
-        // Remove first part
-        array_shift($parts);
+        $removeFirstLocale = true;
+        if (null !== $this->default &&
+            isset($parts[0]) &&
+            !in_array($parts[0], $event->getSupported(), true) &&
+            $parts[0] !== $this->default
+        ) {
+            $removeFirstLocale = false;
+        }
+
+        if (true === $removeFirstLocale) {
+            // Remove first part
+            array_shift($parts);
+        }
+
 
         if ($locale === $this->default) {
             $locale = '';

--- a/src/SlmLocale/Strategy/UriPathStrategy.php
+++ b/src/SlmLocale/Strategy/UriPathStrategy.php
@@ -245,11 +245,12 @@ class UriPathStrategy extends AbstractStrategy
 
     /**
      * @param SimpleRouteStack $router
-     * @return self
+     * @return $this
      */
     public function setRouter($router)
     {
         $this->router = $router;
+
         return $this;
     }
 

--- a/tests/SlmLocaleTest/Strategy/UriPathStrategyTest.php
+++ b/tests/SlmLocaleTest/Strategy/UriPathStrategyTest.php
@@ -420,6 +420,24 @@ class UriPathStrategyTest extends TestCase
         $this->assertSame($expected, $actual);
     }
 
+    public function testAssembleWithDefaultMatchingCurrent()
+    {
+        $uri = new Uri('/foo/bar/baz');
+
+        $this->event->setLocale('en');
+        $this->event->setUri($uri);
+
+        $this->strategy->setOptions([
+            'default' => 'fr',
+        ]);
+        $this->strategy->assemble($this->event);
+
+        $expected = '/en/foo/bar/baz';
+        $actual   = $this->event->getUri()->getPath();
+
+        $this->assertSame($expected, $actual);
+    }
+
     protected function getPluginManager($console = false)
     {
         $sl = new ServiceManager();

--- a/tests/SlmLocaleTest/Strategy/UriPathStrategyTest.php
+++ b/tests/SlmLocaleTest/Strategy/UriPathStrategyTest.php
@@ -454,6 +454,37 @@ class UriPathStrategyTest extends TestCase
         $this->assertSame('/my-app/en/foo/bar/baz', $this->event->getUri()->getPath());
     }
 
+    public function testAssembleWithDefaultWithBasePathWithMatchingPubic()
+    {
+        $uri = new Uri('/my-app/public/foo/bar/baz');
+
+        $this->event->setLocale('en');
+        $this->event->setUri($uri);
+
+        $this->router->setBaseUrl('/my-app/public');
+        $this->strategy = new UriPathStrategy($this->router);
+        $this->strategy->setOptions([
+            'default' => 'nl',
+        ]);
+        $this->strategy->assemble($this->event);
+
+        $this->assertSame('/my-app/public/en/foo/bar/baz', $this->event->getUri()->getPath());
+    }
+
+    public function testAssembleWithBasePathWithMatchingLanguageName()
+    {
+        $uri = new Uri('/my-app/nl/nl/foo/bar/baz');
+
+        $this->event->setLocale('en');
+        $this->event->setUri($uri);
+
+        $this->router->setBaseUrl('/my-app/nl/nl');
+        $this->strategy = new UriPathStrategy($this->router);
+        $this->strategy->assemble($this->event);
+
+        $this->assertSame('/my-app/nl/en/foo/bar/baz', $this->event->getUri()->getPath());
+    }
+
     public function testDisableUriPathStrategyPhpunit()
     {
         $_SERVER['DISABLE_URIPATHSTRATEGY'] = true;

--- a/tests/SlmLocaleTest/Strategy/UriPathStrategyTest.php
+++ b/tests/SlmLocaleTest/Strategy/UriPathStrategyTest.php
@@ -127,8 +127,7 @@ class UriPathStrategyTest extends TestCase
         $this->event->setResponse(new HttpResponse());
 
         $locale   = $this->strategy->detect($this->event);
-        $expected = 'en';
-        $this->assertEquals($expected, $locale);
+        $this->assertSame('en', $locale);
     }
 
     public function testFoundRedirectsByDefault()
@@ -391,6 +390,7 @@ class UriPathStrategyTest extends TestCase
         $this->event->setLocale('en');
         $this->event->setUri($uri);
 
+        $this->strategy->getRouter()->setBaseUrl('/nl');
         $this->strategy->setOptions([
             'default' => 'en',
         ]);
@@ -404,20 +404,18 @@ class UriPathStrategyTest extends TestCase
 
     public function testAssembleWithDefaultNotMatching()
     {
-        $uri = new Uri('/nl/foo/bar/baz');
+        $uri = new Uri('/n1/foo/bar/baz');
 
         $this->event->setLocale('en');
         $this->event->setUri($uri);
 
+        $this->strategy->getRouter()->setBaseUrl('/nl');
         $this->strategy->setOptions([
             'default' => 'fr',
         ]);
         $this->strategy->assemble($this->event);
 
-        $expected = '/en/foo/bar/baz';
-        $actual   = $this->event->getUri()->getPath();
-
-        $this->assertSame($expected, $actual);
+        $this->assertSame('/en/foo/bar/baz', $this->event->getUri()->getPath());
     }
 
     public function testDisableUriPathStrategyPhpunit()
@@ -454,10 +452,7 @@ class UriPathStrategyTest extends TestCase
         ]);
         $this->strategy->assemble($this->event);
 
-        $expected = '/en/foo/bar/baz';
-        $actual   = $this->event->getUri()->getPath();
-
-        $this->assertSame($expected, $actual);
+        $this->assertSame('/en/foo/bar/baz', $this->event->getUri()->getPath());
     }
 
     protected function getPluginManager($console = false)

--- a/tests/SlmLocaleTest/Strategy/UriPathStrategyTest.php
+++ b/tests/SlmLocaleTest/Strategy/UriPathStrategyTest.php
@@ -390,7 +390,8 @@ class UriPathStrategyTest extends TestCase
         $this->event->setLocale('en');
         $this->event->setUri($uri);
 
-        $this->strategy->getRouter()->setBaseUrl('/nl');
+        $this->router->setBaseUrl('/nl');
+        $this->strategy = new UriPathStrategy($this->router);
         $this->strategy->setOptions([
             'default' => 'en',
         ]);
@@ -409,13 +410,48 @@ class UriPathStrategyTest extends TestCase
         $this->event->setLocale('en');
         $this->event->setUri($uri);
 
-        $this->strategy->getRouter()->setBaseUrl('/nl');
+        $this->router->setBaseUrl('/nl');
+        $this->strategy = new UriPathStrategy($this->router);
         $this->strategy->setOptions([
             'default' => 'fr',
         ]);
         $this->strategy->assemble($this->event);
 
         $this->assertSame('/en/foo/bar/baz', $this->event->getUri()->getPath());
+    }
+
+    public function testAssembleWithDefaultWithBasePath()
+    {
+        $uri = new Uri('/my-app/nl/foo/bar/baz');
+
+        $this->event->setLocale('en');
+        $this->event->setUri($uri);
+
+        $this->router->setBaseUrl('/my-app/nl');
+        $this->strategy = new UriPathStrategy($this->router);
+        $this->strategy->setOptions([
+            'default' => 'fr',
+        ]);
+        $this->strategy->assemble($this->event);
+
+        $this->assertSame('/my-app/en/foo/bar/baz', $this->event->getUri()->getPath());
+    }
+
+    public function testAssembleWithDefaultWithBasePathWithMatching()
+    {
+        $uri = new Uri('/my-app/foo/bar/baz');
+
+        $this->event->setLocale('en');
+        $this->event->setUri($uri);
+
+        $this->router->setBaseUrl('/my-app');
+        $this->strategy = new UriPathStrategy($this->router);
+        $this->strategy->setOptions([
+            'default' => 'nl',
+        ]);
+        $this->strategy->assemble($this->event);
+
+        $this->assertSame('/my-app/en/foo/bar/baz', $this->event->getUri()->getPath());
     }
 
     public function testDisableUriPathStrategyPhpunit()

--- a/tests/SlmLocaleTest/Strategy/UriPathStrategyTest.php
+++ b/tests/SlmLocaleTest/Strategy/UriPathStrategyTest.php
@@ -168,6 +168,46 @@ class UriPathStrategyTest extends TestCase
         $this->assertFalse($header);
     }
 
+    public function testFoundRedirectsByDefaultWithBasePath()
+    {
+        $uri     = 'http://example.com/my-app/public/nl/some/deep/path/some.file?withsomeparam=true';
+        $request = new HttpRequest();
+        $request->setUri($uri);
+        $request->setBasePath('/my-app/public');
+
+        $this->event->setLocale('en');
+        $this->event->setRequest($request);
+        $this->event->setResponse(new HttpResponse());
+
+        $this->strategy->found($this->event);
+
+        $statusCode = $this->event->getResponse()->getStatusCode();
+        $header     = $this->event->getResponse()->getHeaders()->get('Location');
+        $expected   = 'Location: http://example.com/my-app/public/en/some/deep/path/some.file?withsomeparam=true';
+        $this->assertEquals(302, $statusCode);
+        $this->assertContains($expected, (string) $header);
+    }
+
+    public function testFoundRedirectsByDefaultWithBasePathDisabledRedirectWhenFound()
+    {
+        $this->strategy->setOptions(['redirect_when_found' => false]);
+        $uri     = 'http://example.com/my-app/public/nl/some/deep/path/some.file?withsomeparam=true';
+        $request = new HttpRequest();
+        $request->setUri($uri);
+        $request->setBasePath('/my-app/public');
+
+        $this->event->setLocale('en');
+        $this->event->setRequest($request);
+        $this->event->setResponse(new HttpResponse());
+
+        $this->strategy->found($this->event);
+
+        $statusCode = $this->event->getResponse()->getStatusCode();
+        $header     = $this->event->getResponse()->getHeaders()->has('Location');
+        $this->assertNotEquals(302, $statusCode);
+        $this->assertFalse($header);
+    }
+
     // public function testFoundWithDisabledRedirectWhenFoundOptionLocaleShouldStillBeDirectedAnywayWhenPathContainsNothingFurther()
     // {
     //     $this->strategy->setOptions(['redirect_when_found' => false]);

--- a/tests/SlmLocaleTest/Strategy/UriPathStrategyTest.php
+++ b/tests/SlmLocaleTest/Strategy/UriPathStrategyTest.php
@@ -404,7 +404,7 @@ class UriPathStrategyTest extends TestCase
 
     public function testAssembleWithDefaultNotMatching()
     {
-        $uri = new Uri('/n1/foo/bar/baz');
+        $uri = new Uri('/nl/foo/bar/baz');
 
         $this->event->setLocale('en');
         $this->event->setUri($uri);


### PR DESCRIPTION
sry had a little bug, with locale url change generation

current url: `/`
url for en: `/en`

current url: `/currency/foobar`
url for en: `/en/foobar` // wrong currency was missing

that i fixed with this change